### PR TITLE
Implement `annotate`

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -5,7 +5,8 @@ from mock import Mock, MagicMock, PropertyMock
 from .constants import *
 from .exceptions import *
 from .utils import (
-    matches, merge, intersect, get_attribute, validate_mock_set, is_list_like_iter, flatten_list, truncate, hash_dict
+    matches, merge, intersect, get_attribute, validate_mock_set, is_list_like_iter, flatten_list, truncate,
+    hash_dict, filter_results
 )
 
 
@@ -79,33 +80,11 @@ class MockSet(MagicMock):
             self.items.append(model)
             self.fire(model, self.EVENT_ADDED, self.EVENT_SAVED)
 
-    def _filter_single_q(self, source, q_obj, negated):
-        if isinstance(q_obj, DjangoQ):
-            return self._filter_q(source, q_obj)
-        else:
-            return matches(negated=negated, *source, **{q_obj[0]: q_obj[1]})
-
-    def _filter_q(self, source, query):
-        results = []
-
-        for child in query.children:
-            filtered = self._filter_single_q(source, child, query.negated)
-
-            if filtered:
-                if not results or query.connector == CONNECTORS_OR:
-                    results = merge(results, filtered)
-                else:
-                    results = intersect(results, filtered)
-            elif query.connector == CONNECTORS_AND:
-                return []
-
-        return results
-
     def filter(self, *args, **attrs):
         results = list(self.items)
         for x in args:
             if isinstance(x, DjangoQ):
-                results = self._filter_q(results, x)
+                results = filter_results(results, x)
             else:
                 raise ArgumentNotSupported()
         return MockSet(*matches(*results, **attrs), clone=self)
@@ -117,6 +96,24 @@ class MockSet(MagicMock):
 
     def exists(self):
         return len(self.items) > 0
+
+    def in_bulk(self, id_list=None, *, field_name='pk'):
+        result = {}
+        for model in self.items:
+            if id_list is None or model.pk in id_list:
+                result[getattr(model, field_name)] = model
+        return result
+
+    def annotate(self, **kwargs):
+        results = list(self.items)
+        for key, value in kwargs.items():
+            for row in results:
+                if not hasattr(row, '_annotated_fields'):
+                    row._annotated_fields = []
+                row._annotated_fields.append(key)
+                setattr(row, key, get_attribute(row, value)[0])
+
+        return MockSet(*results, clone=self)
 
     def aggregate(self, *args, **kwargs):
         result = {}

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -5,7 +5,7 @@ from mock import Mock, MagicMock, PropertyMock
 from .constants import *
 from .exceptions import *
 from .utils import (
-    matches, merge, intersect, get_attribute, validate_mock_set, is_list_like_iter, flatten_list, truncate,
+    matches, get_attribute, validate_mock_set, is_list_like_iter, flatten_list, truncate,
     hash_dict, filter_results
 )
 

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -71,9 +71,11 @@ def find_field_names_from_obj(obj, **kwargs):
 
 def find_field_names(obj, **kwargs):
     if hasattr(obj, '_meta'):
-        lookup_fields, actual_fields = find_field_names_from_meta(obj._meta,
-                                                                  annotated=getattr(obj,'_annotated_fields', []),
-                                                                  **kwargs)
+        lookup_fields, actual_fields = find_field_names_from_meta(
+            obj._meta,
+            annotated=getattr(obj, '_annotated_fields', []),
+            **kwargs
+        )
     else:
         lookup_fields, actual_fields = find_field_names_from_obj(obj, **kwargs)
 
@@ -323,6 +325,7 @@ def filter_results(source, query):
             return []
 
     return results
+
 
 def _filter_single_q(source, q_obj, negated):
     if isinstance(q_obj, DjangoQ):

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -1,5 +1,7 @@
 from datetime import datetime, date
 from django.core.exceptions import FieldError
+from django.db.models import F, Value, Case
+from django.db.models.functions import Coalesce
 from mock import Mock
 
 from .constants import *
@@ -27,15 +29,16 @@ def get_field_mapping(field):
         return {name: name}
 
 
-def find_field_names_from_meta(meta, **kwargs):
+def find_field_names_from_meta(meta, annotated=None, **kwargs):
     field_names = {}
+    annotated = annotated or []
     concrete_only = kwargs.get('concrete_only', False)
 
     if concrete_only:
-        fields_no_mapping = [f.attname for f in meta.concrete_fields]
+        fields_no_mapping = [f.attname for f in meta.concrete_fields] + annotated
         fields_with_mapping = []
     else:
-        fields_no_mapping = [f for f in meta._forward_fields_map.keys()]
+        fields_no_mapping = [f for f in meta._forward_fields_map.keys()] + annotated
         fields_with_mapping = [f for f in meta.fields_map.values()]
 
         for parent in meta.parents.keys():
@@ -68,7 +71,9 @@ def find_field_names_from_obj(obj, **kwargs):
 
 def find_field_names(obj, **kwargs):
     if hasattr(obj, '_meta'):
-        lookup_fields, actual_fields = find_field_names_from_meta(obj._meta, **kwargs)
+        lookup_fields, actual_fields = find_field_names_from_meta(obj._meta,
+                                                                  annotated=getattr(obj,'_annotated_fields', []),
+                                                                  **kwargs)
     else:
         lookup_fields, actual_fields = find_field_names_from_obj(obj, **kwargs)
 
@@ -102,6 +107,21 @@ def get_field_value(obj, field_name, default=None):
 def get_attribute(obj, attr, default=None):
     result = obj
     comparison = None
+    if isinstance(attr, F):
+        attr = attr.deconstruct()[1][0]
+    elif isinstance(attr, Value):
+        return attr.value, None
+    elif isinstance(attr, Case):
+        for case in attr.cases:
+            if filter_results([obj], case.condition):
+                return get_attribute(obj, case.result)
+        else:
+            return get_attribute(obj, attr.default)
+    elif isinstance(attr, Coalesce):
+        for expr in attr.source_expressions:
+            res, comp = get_attribute(obj, expr)
+            if res is not None:
+                return res, comp
     parts = attr.split('__')
 
     for i, attr_part in enumerate(parts):
@@ -286,3 +306,26 @@ def hash_dict(obj, *fields):
     obj_values = {f: get_field_value(obj, f) for f in field_names}
 
     return hash(tuple(sorted((k, v) for k, v in obj_values.items() if not fields or k in fields)))
+
+
+def filter_results(source, query):
+    results = []
+
+    for child in query.children:
+        filtered = _filter_single_q(source, child, query.negated)
+
+        if filtered:
+            if not results or query.connector == CONNECTORS_OR:
+                results = merge(results, filtered)
+            else:
+                results = intersect(results, filtered)
+        elif query.connector == CONNECTORS_AND:
+            return []
+
+    return results
+
+def _filter_single_q(source, q_obj, negated):
+    if isinstance(q_obj, DjangoQ):
+        return filter_results(source, q_obj)
+    else:
+        return matches(negated=negated, *source, **{q_obj[0]: q_obj[1]})

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -133,10 +133,13 @@ class MockOneToManyTests(TestCase):
     @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
     def test_set(self):
         m = Manufacturer()
-        car = Car(speed=95)
-        m.car_set.add(car)
+        car_1 = Car(speed=95)
+        car_2 = Car(speed=40)
+        m.car_set.add(car_1)
+        m.car_set.add(car_2)
 
-        self.assertIs(m.car_set.first(), car)
+        self.assertIs(m.car_set.first(), car_1)
+        self.assertEqual(list(m.car_set.all()), [car_1, car_2])
 
     @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
     def test_set_on_individual_object(self):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -978,15 +978,40 @@ class TestQuery(TestCase):
             str_value=models.Value('data', output_field=models.TextField()),
             bool_value=models.Value(True, output_field=models.BooleanField()),
             int_value=models.Value(10, output_field=models.IntegerField()),
-            is_golf=models.Case(models.When(car__model='golf', then=True), default=False, output_field=models.BooleanField()),
+            is_golf=models.Case(
+                models.When(car__model='golf', then=True),
+                default=False,
+                output_field=models.BooleanField()
+            ),
             color_or_car=Coalesce('color', models.F('car__model')),
         )
 
         values_res = list(qs.values('model', 'str_value', 'bool_value', 'int_value', 'is_golf', 'color_or_car'))
         self.assertEqual([
-            {'model': 'golf', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': True, 'color_or_car': 'green'},
-            {'model': 'polo', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': False, 'color_or_car': 'red'},
-            {'model': 'kia', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': False, 'color_or_car': 'kia'},
+            {
+                'model': 'golf',
+                'int_value': 10,
+                'str_value': 'data',
+                'bool_value': True,
+                'is_golf': True,
+                'color_or_car': 'green'
+            },
+            {
+                'model': 'polo',
+                'int_value': 10,
+                'str_value': 'data',
+                'bool_value': True,
+                'is_golf': False,
+                'color_or_car': 'red'
+            },
+            {
+                'model': 'kia',
+                'int_value': 10,
+                'str_value': 'data',
+                'bool_value': True,
+                'is_golf': False,
+                'color_or_car': 'kia'
+            },
         ], values_res)
 
         first = qs[0]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,7 +4,9 @@ from mock import MagicMock
 from unittest import TestCase
 
 from django.core.exceptions import FieldError
+from django.db.models.functions import Coalesce
 from django.db.models import Q, Avg
+from django.db import models
 
 from django_mock_queries.constants import *
 from django_mock_queries.exceptions import ModelNotSpecified, ArgumentNotSupported
@@ -956,6 +958,54 @@ class TestQuery(TestCase):
 
             assert (make.name, polo.model, polo_white.color) in data
             assert (make.name, golf.model, golf_black.color) in data
+
+    def test_in_bulk(self):
+        golf = Car(model='golf', id=1)
+        polo = Car(model='polo', id=2)
+        kia = Car(model='kia', id=4)
+        qs = MockSet(golf, polo, kia)
+
+        self.assertEqual(qs.in_bulk(), {1: golf, 2: polo, 4: kia})
+        self.assertEqual(qs.in_bulk(id_list=[4], field_name='model'), {'kia': kia})
+
+    def test_annotate(self):
+        qs = MockSet(CarVariation(color='green', car=Car(model='golf', id=1), id=1),
+                     CarVariation(color='red', car=Car(model='polo', id=2), id=2),
+                     CarVariation(color=None, car=Car(model='kia', id=3), id=3),
+                     )
+        qs = qs.annotate(
+            model=models.F('car__model'),
+            str_value=models.Value('data', output_field=models.TextField()),
+            bool_value=models.Value(True, output_field=models.BooleanField()),
+            int_value=models.Value(10, output_field=models.IntegerField()),
+            is_golf=models.Case(models.When(car__model='golf', then=True), default=False, output_field=models.BooleanField()),
+            color_or_car=Coalesce('color', models.F('car__model')),
+        )
+
+        values_res = list(qs.values('model', 'str_value', 'bool_value', 'int_value', 'is_golf', 'color_or_car'))
+        self.assertEqual([
+            {'model': 'golf', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': True, 'color_or_car': 'green'},
+            {'model': 'polo', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': False, 'color_or_car': 'red'},
+            {'model': 'kia', 'int_value': 10, 'str_value': 'data', 'bool_value': True, 'is_golf': False, 'color_or_car': 'kia'},
+        ], values_res)
+
+        first = qs[0]
+        self.assertEqual(first.model, 'golf')
+        self.assertEqual(first.color_or_car, 'green')
+        self.assertEqual(first.is_golf, True)
+        self.assertEqual(first.int_value, 10)
+        self.assertEqual(first.str_value, 'data')
+        self.assertEqual(first.bool_value, True)
+
+        second = qs[1]
+        self.assertEqual(second.model, 'polo')
+        self.assertEqual(second.color_or_car, 'red')
+        self.assertEqual(second.is_golf, False)
+        self.assertEqual(second.int_value, 10)
+        self.assertEqual(second.str_value, 'data')
+        self.assertEqual(second.bool_value, True)
+
+        self.assertEqual(qs[2].color_or_car, 'kia')
 
     def test_query_values_raises_attribute_error_when_field_is_not_in_meta_concrete_fields(self):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))


### PR DESCRIPTION
https://github.com/stphivos/django-mock-queries/pull/135

Cherry-picked the above MR onto v2.1.5 (the version SDE uses) and fixed the flake8 errors.

Ran tox locally for SDE's versions of python, django, and drf. Tests passed.
`py{36}-dj{22}-drf{312}` = python 3.6, django 2.2, djangorestframework 3.12